### PR TITLE
fix: configure release workflows to trigger properly

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Build and Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag name (e.g., v0.1.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,6 +17,8 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
     strategy:
       matrix:
         include:
@@ -52,34 +60,36 @@ jobs:
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz mote
-          mv mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz ../../../
+          tar czf mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz mote
+          mv mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz ../../../
 
       - name: Calculate SHA256
         id: sha
         run: |
-          echo "sha256=$(shasum -a 256 mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "sha256=$(shasum -a 256 mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: mote-${{ matrix.target }}
-          path: mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz
+          path: mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz
 
       - name: Save SHA256
         run: |
-          echo "${{ steps.sha.outputs.sha256 }}  mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz" > mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.sha256
+          echo "${{ steps.sha.outputs.sha256 }}  mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz" > mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.sha256
 
       - name: Upload SHA256
         uses: actions/upload-artifact@v4
         with:
           name: sha256-${{ matrix.target }}
-          path: mote-${{ github.event.release.tag_name }}-${{ matrix.target }}.sha256
+          path: mote-${{ env.RELEASE_TAG }}-${{ matrix.target }}.sha256
 
   upload-assets:
     name: Upload Release Assets
     needs: build
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -90,6 +100,7 @@ jobs:
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             mote-*/mote-*.tar.gz
             sha256-*/mote-*.sha256
@@ -100,6 +111,8 @@ jobs:
     name: Update Homebrew Formula
     needs: upload-assets
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
     steps:
       - name: Checkout mote repository
         uses: actions/checkout@v4
@@ -127,7 +140,7 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          VERSION=${{ github.event.release.tag_name }}
+          VERSION=${{ env.RELEASE_TAG }}
           VERSION=${VERSION#v}  # Remove 'v' prefix if present
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -157,5 +170,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/mote.rb
-          git commit -m "chore: update mote to ${{ github.event.release.tag_name }}"
+          git commit -m "chore: update mote to ${{ env.RELEASE_TAG }}"
           git push


### PR DESCRIPTION
## 概要
リリースPRマージ時に`Build and Release`ワークフローが自動実行されない問題を修正しました。

## 変更内容

### 1. release-please.ymlの修正
- `GITHUB_TOKEN` → `RELEASE_PLEASE_TOKEN`に変更
- これにより、release-pleaseが作成するリリースイベントが他のワークフローをトリガーできるようになります

### 2. release.ymlの改善
- `workflow_dispatch`トリガーを追加し、手動実行を可能に
- `RELEASE_TAG`環境変数を導入して、自動/手動両方のトリガーに対応
- すべての`github.event.release.tag_name`を`env.RELEASE_TAG`に統一

## 動作確認
このPRマージ後、以下の方法でv0.1.1のビルドを実行できます：

```bash
gh workflow run release.yml -f tag_name=v0.1.1
```

## 関連issue
fixes #3 (もしissueがあれば)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to improve release automation and token handling. These internal infrastructure changes do not affect end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->