### PR TITLE
fix: use RELEASE_PLEASE_TOKEN for homebrew-tap access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: shabaraba/homebrew-tap
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           path: tap
 
       - name: Copy Formula to tap


### PR DESCRIPTION
## 概要
Homebrew formulaの自動更新時に発生していたトークンエラーを修正しました。

## 問題
v0.1.1のリリース時、`Update Homebrew Formula`ジョブが以下のエラーで失敗：
```
Input required and not supplied: token
```

## 原因
`TAP_GITHUB_TOKEN`シークレットが設定されていなかった。

## 解決策
既存の`RELEASE_PLEASE_TOKEN`を再利用することで、別途トークンを管理する必要をなくしました。

### 変更内容
- `release.yml`の`Checkout tap repository`ステップで`TAP_GITHUB_TOKEN`の代わりに`RELEASE_PLEASE_TOKEN`を使用

## 動作確認
このPRマージ後、v0.1.1のワークフローを再実行してHomebrew formulaが正しく更新されることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication configuration to ensure proper credential handling during the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->