### PR TITLE
fix: correct Homebrew formula URL pattern to include 'v' prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,10 @@ jobs:
         run: |
           cd mote/homebrew-formula
           sed -i "s/version \".*\"/version \"${{ steps.version.outputs.version }}\"/g" mote.rb
-          sed -i "s/sha256 \"[0-9a-f]\{64\}\" # ARM64 macOS/sha256 \"${{ steps.sha.outputs.arm64_mac }}\" # ARM64 macOS/g" mote.rb
-          sed -i "s/sha256 \"[0-9a-f]\{64\}\" # x86_64 macOS/sha256 \"${{ steps.sha.outputs.x86_64_mac }}\" # x86_64 macOS/g" mote.rb
-          sed -i "s/sha256 \"[0-9a-f]\{64\}\" # ARM64 Linux/sha256 \"${{ steps.sha.outputs.arm64_linux }}\" # ARM64 Linux/g" mote.rb
-          sed -i "s/sha256 \"[0-9a-f]\{64\}\" # x86_64 Linux/sha256 \"${{ steps.sha.outputs.x86_64_linux }}\" # x86_64 Linux/g" mote.rb
+          sed -i "s|sha256 \"[0-9a-f]\{64\}\" # ARM64 macOS|sha256 \"${{ steps.sha.outputs.arm64_mac }}\" # ARM64 macOS|g" mote.rb
+          sed -i "s|sha256 \"[0-9a-f]\{64\}\" # x86_64 macOS|sha256 \"${{ steps.sha.outputs.x86_64_mac }}\" # x86_64 macOS|g" mote.rb
+          sed -i "s|sha256 \"[0-9a-f]\{64\}\" # ARM64 Linux|sha256 \"${{ steps.sha.outputs.arm64_linux }}\" # ARM64 Linux|g" mote.rb
+          sed -i "s|sha256 \"[0-9a-f]\{64\}\" # x86_64 Linux|sha256 \"${{ steps.sha.outputs.x86_64_linux }}\" # x86_64 Linux|g" mote.rb
 
       - name: Checkout tap repository
         uses: actions/checkout@v4

--- a/homebrew-formula/mote.rb
+++ b/homebrew-formula/mote.rb
@@ -1,25 +1,25 @@
 class Mote < Formula
   desc "A fine-grained snapshot management tool for projects"
   homepage "https://github.com/shabaraba/mote"
-  version "0.1.0"
+  version "0.1.1"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "REPLACE_WITH_ACTUAL_SHA256_ARM64"
+      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "af0103373631d22b48d3637dcfc63f9f709e488598aa444ffdac055e90ac0014" # ARM64 macOS
     else
-      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "REPLACE_WITH_ACTUAL_SHA256_X86_64"
+      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "b9537a128b010f80cde98cd5780dee7a970627ddca93b42e2c6bf0d1f6301df9" # x86_64 macOS
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-#{version}-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "REPLACE_WITH_ACTUAL_SHA256_LINUX_ARM64"
+      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "c5f261c6b87a0193914fe9a50681460f63f75b797434f522acc64063b61d2e03" # ARM64 Linux
     else
-      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "REPLACE_WITH_ACTUAL_SHA256_LINUX_X86_64"
+      url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "097b3aa386dde0fcdf5061aa47adc7fb940ddb202a679ac40c0883e62ba91238" # x86_64 Linux
     end
   end
 


### PR DESCRIPTION
## 問題
`brew install mote`が以下のエラーで失敗：
```
Error: Failed to download resource "mote (0.1.1)"
Download failed: https://github.com/shabaraba/mote/releases/download/v0.1.1/mote-0.1.1-aarch64-apple-darwin.tar.gz
```

## 原因
リリースアセットのファイル名には`v`プレフィックスが含まれている（`mote-v0.1.1-...`）のに対し、
Homebrewのformulaは`mote-0.1.1-...`を探していた。

## 修正内容
- Homebrew formulaのURLパターンを`mote-#{version}`から`mote-v#{version}`に修正
- v0.1.1の正しいSHA256値を設定
- `release.yml`のsedコマンドの区切り文字を変更してエスケープ問題を回避

## テスト
このPRマージ後、以下でインストール可能になります：
```bash
brew install shabaraba/tap/mote
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)