### PR TITLE
fix: update SHA256 checksums to match actual v0.1.1 release assets

### DIFF
--- a/homebrew-formula/mote.rb
+++ b/homebrew-formula/mote.rb
@@ -6,20 +6,20 @@ class Mote < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "af0103373631d22b48d3637dcfc63f9f709e488598aa444ffdac055e90ac0014" # ARM64 macOS
+      sha256 "ea3105fba8c9dbb4e79ff7b42ac4055e944e7bd1658f6a66011c6166ee92111c" # ARM64 macOS
     else
       url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "b9537a128b010f80cde98cd5780dee7a970627ddca93b42e2c6bf0d1f6301df9" # x86_64 macOS
+      sha256 "90ba80465484d009cb33fa46bb909a35546347d5b8481cb6034e3658666bc295" # x86_64 macOS
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "c5f261c6b87a0193914fe9a50681460f63f75b797434f522acc64063b61d2e03" # ARM64 Linux
+      sha256 "d1ee0737bf65e14a1c5b874b58788a0f360ee364edd5b4ff262d982615061a95" # ARM64 Linux
     else
       url "https://github.com/shabaraba/mote/releases/download/v#{version}/mote-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "097b3aa386dde0fcdf5061aa47adc7fb940ddb202a679ac40c0883e62ba91238" # x86_64 Linux
+      sha256 "f74ee5159bb431a57de0bfbd196a0b2782698416eb6e8b3f724eee25a5303393" # x86_64 Linux
     end
   end
 


### PR DESCRIPTION
## 問題
Homebrewインストール時にSHA256チェックサムエラー：
```
Error: Formula reports different checksum: af0103373631d22b48d3637dcfc63f9f709e488598aa444ffdac055e90ac0014
SHA-256 checksum of downloaded file: ea3105fba8c9dbb4e79ff7b42ac4055e944e7bd1658f6a66011c6166ee92111c
```

## 原因
Formulaに記載されていたSHA256が、実際のv0.1.1リリースアセットのチェックサムと一致していませんでした。

## 修正内容
実際のリリースアセットから正しいSHA256を取得して更新：
- ARM64 macOS: `ea3105fba8c9dbb4e79ff7b42ac4055e944e7bd1658f6a66011c6166ee92111c`
- x86_64 macOS: `90ba80465484d009cb33fa46bb909a35546347d5b8481cb6034e3658666bc295`
- ARM64 Linux: `d1ee0737bf65e14a1c5b874b58788a0f360ee364edd5b4ff262d982615061a95`
- x86_64 Linux: `f74ee5159bb431a57de0bfbd196a0b2782698416eb6e8b3f724eee25a5303393`

🤖 Generated with [Claude Code](https://claude.com/claude-code)