### PR TITLE
fix: update Cargo.toml version and change release-type to rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mote"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A fine-grained snapshot management tool for projects"
 license = "MIT"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "simple",
+      "release-type": "rust",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
## 問題
`mote --version`が`0.1.0`を表示していますが、実際のリリースは`v0.1.1`です。

## 原因
1. release-pleaseの設定が`release-type: simple`だったため、Cargo.tomlが自動更新されませんでした
2. Cargo.tomlのバージョンが手動で更新されていませんでした

## 修正内容
- Cargo.tomlのバージョンを0.1.1に更新
- release-please-config.jsonを`release-type: rust`に変更
  - 今後はCargo.tomlとCargo.lockが自動的に更新されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)